### PR TITLE
Remove remote copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,6 @@ $ es-cli remove alias <alias_name> <index_name1> <index_name2> ...
 $ es-cli list alias <alias_name>
 ```
 
-### Experimental API(thinking interface)
-```
-$ es-cli copy remote remoteHost copyIndexName user pass (type or not)
-```
-
 ## Configuration
 You can use configuration file.
 es-cli see options order by command options > current directory.

--- a/infra/es/base_client.go
+++ b/infra/es/base_client.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/rerost/es-cli/config"
-	"github.com/rerost/es-cli/setting"
 	"github.com/srvc/fail"
 )
 
@@ -147,14 +146,9 @@ type baseClientImp struct {
 	HttpClient *http.Client
 }
 
-func NewBaseClient(ctx context.Context, httpClient *http.Client) (BaseClient, error) {
+func NewBaseClient(cfg config.Config, httpClient *http.Client) (BaseClient, error) {
 	client := baseClientImp{}
 	client.HttpClient = httpClient
-
-	cfg, ok := ctx.Value(setting.SettingKey("config")).(config.Config)
-	if !ok {
-		return client, fail.New("Failed to extract config")
-	}
 	client.Config = cfg
 
 	return client, nil

--- a/infra/es/base_client_test.go
+++ b/infra/es/base_client_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/rerost/es-cli/config"
 	"github.com/rerost/es-cli/infra/es"
-	"github.com/rerost/es-cli/setting"
 )
 
 func TestNewClient(t *testing.T) {
@@ -21,10 +20,8 @@ func TestNewClient(t *testing.T) {
 		Type: "_doc",
 	}
 
-	ctx = context.WithValue(ctx, setting.SettingKey("config"), cfg)
-
 	httpClient := new(http.Client)
-	_, err := es.NewBaseClient(ctx, httpClient)
+	_, err := es.NewBaseClient(cfg, httpClient)
 	if err != nil {
 		t.Errorf("Failed to create base client: %v", err)
 	}
@@ -79,8 +76,7 @@ func TestListIndex(t *testing.T) {
 				Host: host,
 				Type: "_doc",
 			}
-			ctx = context.WithValue(ctx, setting.SettingKey("config"), cfg)
-			baseClient, _ := es.NewBaseClient(ctx, ts.Client())
+			baseClient, _ := es.NewBaseClient(cfg, ts.Client())
 			indices, err := baseClient.ListIndex(ctx)
 
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/rerost/es-cli/config"
 	"github.com/rerost/es-cli/executer"
 	"github.com/rerost/es-cli/infra/es"
-	"github.com/rerost/es-cli/setting"
 	"github.com/srvc/fail"
 	"github.com/urfave/cli"
 	"gopkg.in/guregu/null.v3"
@@ -68,9 +67,7 @@ func main() {
 			httpClient = new(http.Client)
 		}
 
-		ctx = context.WithValue(ctx, setting.SettingKey("config"), cfg)
-
-		esBaseClient, err := es.NewBaseClient(ctx, httpClient)
+		esBaseClient, err := es.NewBaseClient(cfg, httpClient)
 		if err != nil {
 			return err
 		}

--- a/setting/setting.go
+++ b/setting/setting.go
@@ -1,3 +1,0 @@
-package setting
-
-type SettingKey string


### PR DESCRIPTION
## WHY
es-cli remote copy is can operate by `dump` and `restore` Api.

So delete it.