### PR TITLE
govet error: Fix bad syntax for struct tag value.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	Type     string    `json:"type"`
 	User     string    `json:"user"`
 	Pass     string    `json:"pass"`
-	Insecure null.Bool `json:"insecure` // Use null.Bool for overwrite.
+	Insecure null.Bool `json:"insecure"` // Use null.Bool for overwrite.
 }
 
 func DefaultConfig() Config {


### PR DESCRIPTION
```
config/config.go:16:2: struct field tag `json:"insecure` not compatible with reflect.StructTag.Get: bad syntax for struct tag value (govet)
	Insecure null.Bool `json:"insecure` // Use null.Bool for overwrite.
```