### PR TITLE
Supports the "include_type_name" parameter when creating an index

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -52,8 +52,8 @@ func NewConfig() (config.Config, error) {
 	pflag.StringP("user", "u", "", "ES basic auth user")
 	pflag.StringP("pass", "p", "", "ES basic auth password")
 	pflag.BoolP("insecure", "k", false, "Same as curl insecure")
-	pflag.StringP("namespace", "n", "localhost", "Specify config in es-cli")                                                  // For conf. Think alter position
-	pflag.Bool("set-include-type-name", false, `Set the API parameter "include_type_name" when creating or updating a index`) // ref. https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html
+	pflag.StringP("namespace", "n", "localhost", "Specify config in es-cli")                                       // For conf. Think alter position
+	pflag.Bool("set-include-type-name", false, `Set the API parameter "include_type_name" when creating an index`) // ref. https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html
 
 	pflag.BoolP("verbose", "v", false, "")
 	pflag.BoolP("debug", "d", false, "")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -52,8 +52,8 @@ func NewConfig() (config.Config, error) {
 	pflag.StringP("user", "u", "", "ES basic auth user")
 	pflag.StringP("pass", "p", "", "ES basic auth password")
 	pflag.BoolP("insecure", "k", false, "Same as curl insecure")
-	pflag.StringP("namespace", "n", "localhost", "Specify config in es-cli") // For conf. Think alter position
-	pflag.Bool("set-include_type_name", false, `Set the API parameter "include_type_name" when creating or updating a index`)
+	pflag.StringP("namespace", "n", "localhost", "Specify config in es-cli")                                                  // For conf. Think alter position
+	pflag.Bool("set-include-type-name", false, `Set the API parameter "include_type_name" when creating or updating a index`) // ref. https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html
 
 	pflag.BoolP("verbose", "v", false, "")
 	pflag.BoolP("debug", "d", false, "")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -53,6 +53,7 @@ func NewConfig() (config.Config, error) {
 	pflag.StringP("pass", "p", "", "ES basic auth password")
 	pflag.BoolP("insecure", "k", false, "Same as curl insecure")
 	pflag.StringP("namespace", "n", "localhost", "Specify config in es-cli") // For conf. Think alter position
+	pflag.Bool("set-include_type_name", false, `Set the API parameter "include_type_name" when creating or updating a index`)
 
 	pflag.BoolP("verbose", "v", false, "")
 	pflag.BoolP("debug", "d", false, "")

--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	User               string `json:"user"`
 	Pass               string `json:"pass"`
 	Insecure           bool   `json:"insecure"` // Use null.Bool for overwrite.
-	SetIncludeTypeName bool   `json:"set-include_type_name"`
+	SetIncludeTypeName bool   `json:"set-include-type-name" mapstructure:"set-include-type-name"`
 	Verbose            bool   `json:"verbose"`
 	Debug              bool   `json:"debug"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -8,13 +8,14 @@ import (
 )
 
 type Config struct {
-	Host     string `json:"host"`
-	Type     string `json:"type"`
-	User     string `json:"user"`
-	Pass     string `json:"pass"`
-	Insecure bool   `json:"insecure"` // Use null.Bool for overwrite.
-	Verbose  bool   `json:"verbose"`
-	Debug    bool   `json:"debug"`
+	Host               string `json:"host"`
+	Type               string `json:"type"`
+	User               string `json:"user"`
+	Pass               string `json:"pass"`
+	Insecure           bool   `json:"insecure"` // Use null.Bool for overwrite.
+	SetIncludeTypeName bool   `json:"set-include_type_name"`
+	Verbose            bool   `json:"verbose"`
+	Debug              bool   `json:"debug"`
 }
 
 func DefaultConfig() Config {
@@ -78,6 +79,9 @@ func Overwrite(cfgOrg, cfgOverwrite Config) Config {
 	}
 	if i := cfgOverwrite.Insecure; i {
 		cfgDst.Insecure = i
+	}
+	if s := cfgOverwrite.SetIncludeTypeName; s {
+		cfgDst.SetIncludeTypeName = s
 	}
 
 	return cfgDst

--- a/infra/es/base_client.go
+++ b/infra/es/base_client.go
@@ -244,9 +244,9 @@ func (client baseClientImp) ListIndex(ctx context.Context) (Indices, error) {
 	return indices, nil
 }
 func (client baseClientImp) CreateIndex(ctx context.Context, indexName string, mappingJSON string) error {
-	params := map[string]string{}
+	var params map[string]string
 	if client.Config.SetIncludeTypeName {
-		params["include_type_name"] = "true"
+		params = map[string]string{"include_type_name": "true"}
 	}
 
 	responseBody, err := client.httpRequest(ctx, http.MethodPut, client.rawIndexURL(indexName), mappingJSON, "application/json", params)

--- a/infra/es/base_client.go
+++ b/infra/es/base_client.go
@@ -170,6 +170,10 @@ func (client baseClientImp) httpRequest(ctx context.Context, method string, url 
 		request = addParams(request, params)
 	}
 
+	if client.Config.SetIncludeTypeName {
+		request = addParams(request, map[string]string{"include_type_name": "true"})
+	}
+
 	if client.Config.User != "" && client.Config.Pass != "" {
 		request.SetBasicAuth(client.Config.User, client.Config.Pass)
 	}

--- a/infra/es/base_client.go
+++ b/infra/es/base_client.go
@@ -170,10 +170,6 @@ func (client baseClientImp) httpRequest(ctx context.Context, method string, url 
 		request = addParams(request, params)
 	}
 
-	if client.Config.SetIncludeTypeName {
-		request = addParams(request, map[string]string{"include_type_name": "true"})
-	}
-
 	if client.Config.User != "" && client.Config.Pass != "" {
 		request.SetBasicAuth(client.Config.User, client.Config.Pass)
 	}
@@ -248,7 +244,13 @@ func (client baseClientImp) ListIndex(ctx context.Context) (Indices, error) {
 	return indices, nil
 }
 func (client baseClientImp) CreateIndex(ctx context.Context, indexName string, mappingJSON string) error {
-	responseBody, err := client.httpRequest(ctx, http.MethodPut, client.rawIndexURL(indexName), mappingJSON, "application/json", nil)
+	params := map[string]string{}
+
+	if client.Config.SetIncludeTypeName {
+		params["include_type_name"] = "true"
+	}
+
+	responseBody, err := client.httpRequest(ctx, http.MethodPut, client.rawIndexURL(indexName), mappingJSON, "application/json", params)
 	if err != nil {
 		return fail.Wrap(err)
 	}

--- a/infra/es/base_client.go
+++ b/infra/es/base_client.go
@@ -244,9 +244,15 @@ func (client baseClientImp) ListIndex(ctx context.Context) (Indices, error) {
 	return indices, nil
 }
 func (client baseClientImp) CreateIndex(ctx context.Context, indexName string, mappingJSON string) error {
-	var params map[string]string
+	params := map[string]string{}
 	if client.Config.SetIncludeTypeName {
-		params = map[string]string{"include_type_name": "true"}
+		params["include_type_name"] = "true"
+	}
+
+	// params must be nil if empty.
+	// Because client.httpRequest() checks whether params is nil or not.
+	if len(params) == 0 {
+		params = nil
 	}
 
 	responseBody, err := client.httpRequest(ctx, http.MethodPut, client.rawIndexURL(indexName), mappingJSON, "application/json", params)

--- a/infra/es/base_client.go
+++ b/infra/es/base_client.go
@@ -245,7 +245,6 @@ func (client baseClientImp) ListIndex(ctx context.Context) (Indices, error) {
 }
 func (client baseClientImp) CreateIndex(ctx context.Context, indexName string, mappingJSON string) error {
 	params := map[string]string{}
-
 	if client.Config.SetIncludeTypeName {
 		params["include_type_name"] = "true"
 	}


### PR DESCRIPTION
## What

Added the flag(`--set-include-type-name`) to set the "include_type_name" parameter when creating an index.

## Why

ref. https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html

Starting with Elasticsearch v7.x, the Typeless API is the default setting. As a result, mappings up to v6.x that include types can no longer be used without modification.

In order to use the mapping used in v6.x without modification in v7.x, a parameter called "include_type_name" is provided. I want to be able to use this.